### PR TITLE
Fix critical TypeScript errors for Vercel build

### DIFF
--- a/src/components/packages/OrganisationSection.vue
+++ b/src/components/packages/OrganisationSection.vue
@@ -81,7 +81,6 @@ import { ref, computed, onMounted } from 'vue'
 import BaseSection from '@/components/ui/BaseSection.vue'
 import BaseHeading from '@/components/ui/BaseHeading.vue'
 import BaseText from '@/components/ui/BaseText.vue'
-import BaseButton from '@/components/ui/BaseButton.vue'
 import PackageDetailCard from '@/components/packages/PackageDetailCard.vue'
 
 const emit = defineEmits<{

--- a/src/components/packages/PortraitFamilySection.vue
+++ b/src/components/packages/PortraitFamilySection.vue
@@ -77,7 +77,6 @@ import { ref, computed, onMounted } from 'vue'
 import BaseSection from '@/components/ui/BaseSection.vue'
 import BaseHeading from '@/components/ui/BaseHeading.vue'
 import BaseText from '@/components/ui/BaseText.vue'
-import BaseButton from '@/components/ui/BaseButton.vue'
 import PackageDetailCard from '@/components/packages/PackageDetailCard.vue'
 
 const emit = defineEmits<{

--- a/src/components/ui/CallToActionSection.vue
+++ b/src/components/ui/CallToActionSection.vue
@@ -128,7 +128,4 @@ const handleSecondaryClick = () => {
   emit('secondary-click')
 }
 
-const handleVoucherClick = () => {
-  emit('voucher-click')
-}
 </script>

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -177,7 +177,6 @@
   import BaseSection from '@/components/ui/BaseSection.vue'
   import BaseHeading from '@/components/ui/BaseHeading.vue'
   import BaseText from '@/components/ui/BaseText.vue'
-  import BaseButton from '@/components/ui/BaseButton.vue'
   import CallToActionSection from '@/components/ui/CallToActionSection.vue'
   import ContentBlock from '@/components/ui/ContentBlock.vue'
   import QuoteBlock from '@/components/ui/QuoteBlock.vue'

--- a/src/views/PackagesView.vue
+++ b/src/views/PackagesView.vue
@@ -112,8 +112,8 @@ onMounted(() => {
   }, 100)
 })
 
-const openBookingModal = (packageAction: string) => {
-  selectedPackageAction.value = packageAction
+const openBookingModal = (packageAction?: string) => {
+  selectedPackageAction.value = packageAction || ''
   showBookingModal.value = true
 }
 
@@ -123,8 +123,9 @@ const closeBookingModal = () => {
 }
 
 
-// Package data
-// const portraitPackages = [
+// Package data (commented out - not currently used)
+/*
+const portraitPackages = [
   {
     title: 'Dust & Light',
     subtitle: 'Mini Session',
@@ -184,6 +185,7 @@ const closeBookingModal = () => {
 ]
 
 // const lifestylePackages = [
+/*
   {
     title: 'Lifestyle & Events',
     subtitle: 'Birthdays, Gatherings & Content',
@@ -223,8 +225,10 @@ const closeBookingModal = () => {
     }
   }
 ]
+*/
 
 // const organizationPackages = [
+/*
   {
     title: 'The Raw Thread',
     subtitle: 'Short Story Package',
@@ -282,4 +286,5 @@ const closeBookingModal = () => {
     }
   }
 ]
+*/
 </script>


### PR DESCRIPTION
- Remove unused BaseButton imports from package components
- Remove unused handleVoucherClick function from CallToActionSection
- Remove unused BaseButton import from AboutView
- Fix syntax errors in PackagesView by properly commenting out unused package data arrays
- Make openBookingModal parameter optional to fix type error
- Build now completes successfully with only minor TS warnings remaining

🤖 Generated with [Claude Code](https://claude.ai/code)